### PR TITLE
Avoid pushing backups if we are not going to create a new one

### DIFF
--- a/src/shell/assorted-scripts/src/incremental-backup.sh
+++ b/src/shell/assorted-scripts/src/incremental-backup.sh
@@ -103,10 +103,24 @@ backup() {
     fi
 }
 
+check_dir_exists() {
+    local dir="$1"
+
+    if [[ ! -r "$dir" ]]; then
+        echo "$dir doesn't exist or is not readable, aborting backup"
+        exit 1
+    fi
+    if [[ ! -d "$dir" ]]; then
+        echo "$dir is not a directory, aborting backup"
+        exit 1
+    fi
+}
+
 ## Main
 ##====================================================================
 main() {
     parse_args "${ARGS[@]:-}"
+    check_dir_exists "$SRC_DIR"
     backup "$SRC_DIR" "$DEST_DIR" "$RETENTION"
 }
 


### PR DESCRIPTION
Otherwise we can easily remove all copies if the current directory is wrong. A
better option would be to push after backing up, but that requires some major
changes